### PR TITLE
Fix the provided package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     
     "provide": {
-        "psr/cache": "1.0.0"
+        "psr/cache-implementation": "1.0.0"
     }
     
 }


### PR DESCRIPTION
This package does not provide the `psr/cache` (which is the package shipping interfaces). It provides an implementation of the interface. This updates the provide rule by using the right virtual package.
